### PR TITLE
Fix in Licenses for when contributor name starts with '@'

### DIFF
--- a/src/Pages/Licenses/licenses.js
+++ b/src/Pages/Licenses/licenses.js
@@ -19,7 +19,12 @@ function extractNameFromGithubUrl(url) {
 function Licenses() {
     let licenses = Object.keys(allData).map((key) => {
         let { licenses, ...license } = allData[key];
-        let [name, version] = key.split("@");
+        let name, version;
+        if (key[0] == '@') {
+            [, name, version] = key.split('@');
+        } else {
+            [name, version] = key.split('@');
+        }
 
         let username =
             extractNameFromGithubUrl(license.repository) ||


### PR DESCRIPTION
Updated Logic to take into account when library name starts with '@', like @react-native-community